### PR TITLE
Fix deprecation of OpenSSL.crypto.sign #9

### DIFF
--- a/src/secret_example.py
+++ b/src/secret_example.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 import OpenSSL.crypto
 import pathlib
 from typing import TYPE_CHECKING, List, Optional, Tuple, Dict, Literal, Union
+from cryptography.hazmat.primitives import serialization
 
 if TYPE_CHECKING:
     from .store import UserStore
@@ -50,8 +51,11 @@ ADMIN_2FA_COOKIE = 'some_long_random_string'
 
 # openssl ecparam -name secp256k1 -genkey -noout -out token.priv
 # openssl req -x509 -key token.priv -out token.pub -days 365
-with open('/path/to/token.priv') as f:
-    TOKEN_SIGNING_KEY = OpenSSL.crypto.load_privatekey(OpenSSL.crypto.FILETYPE_PEM, f.read())
+with open('/path/to/token.priv', 'rb') as f:
+    TOKEN_SIGNING_KEY = serialization.load_pem_private_key(
+        f.read(),
+        password=None,
+    )
 
 ##
 ## DEPLOYMENT CONFIG

--- a/src/utils.py
+++ b/src/utils.py
@@ -29,6 +29,8 @@ from typing import Union, Callable, Dict, Any, Iterator, Literal
 LogLevel = Literal['debug', 'info', 'warning', 'error', 'critical', 'success']
 
 from . import secret
+from cryptography.hazmat.primitives.asymmetric import ec
+from cryptography.hazmat.primitives import hashes
 
 def gen_random_str(length: int = 32, *, crypto: bool = False) -> str:
     choice: Callable[[str], str] = secrets.choice if crypto else random.choice  # type: ignore
@@ -101,7 +103,10 @@ def format_size(size: int) -> str:
         return f'{size/(1024**3):.1f}G'
 
 def sign_token(uid: int) -> str:
-    sig = base64.urlsafe_b64encode(OpenSSL.crypto.sign(secret.TOKEN_SIGNING_KEY, str(uid).encode(), 'sha256')).decode()
+    sig = base64.urlsafe_b64encode(secret.TOKEN_SIGNING_KEY.sign(
+        str(uid).encode(),
+        ec.ECDSA(hashes.SHA256())
+    )).decode()
     return f'{uid}:{sig}'
 
 def get_traceback(e: Exception) -> str:


### PR DESCRIPTION
Fixes #9 

Modify the private key loading in `src/secret_example.py` and update the `sign_token` function in `src/utils.py`.

* **Private Key Loading:**
  - Add import for `serialization` from `cryptography.hazmat.primitives`.
  - Modify the private key loading to use `serialization.load_pem_private_key`.

* **Sign Token Function:**
  - Add imports for `ec` and `hashes` from `cryptography.hazmat.primitives.asymmetric` and `cryptography.hazmat.primitives` respectively.
  - Modify the `sign_token` function to use `secret.TOKEN_SIGNING_KEY.sign` with `ec.ECDSA` and `hashes.SHA256`.

> Made by Copilot Workspace, may contain mistakes

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/PKU-GeekGame/gs-backend/pull/10?shareId=90eee854-735c-4fea-8c28-bb4523dbdf5d).